### PR TITLE
Add disk-usage plugin

### DIFF
--- a/jiro.jsonnet
+++ b/jiro.jsonnet
@@ -58,6 +58,7 @@ local newController(controllerVersion, remotingVersion) = {
     "config-file-provider", # TO_REMOVE, direct dependency of "pipeline-maven"
     "configuration-as-code", # ESSENTIAL Jenkins configuration as code (JCasC)
     "credentials-binding", # withCredentials
+    "disk-usage", # disk usage trend per build, workspace.
     "email-ext", # mailer plugin with a lot more options than 'mailer'
     "extended-read-permission", # allows to show job configuration in read-only mode
     "external-monitor-job", #required for upgrade of core installed version


### PR DESCRIPTION
Since storage quotas have been enforced with the Ceph migration, helping projects better understand their storage usage has become even more crucial.

This plugin will help track storage usage per build and workspace, displaying trends over time.

https://plugins.jenkins.io/disk-usage/